### PR TITLE
html-header.php foreach() loop NULL prevent

### DIFF
--- a/parts/shared/html-header.php
+++ b/parts/shared/html-header.php
@@ -24,9 +24,12 @@
   <?php
       $postTags = get_the_tags();
       $tagNames = array();
-      foreach($postTags as $tag)
+      if ($postTags != NULL )
       {
-          $tagNames[] = $tag->name;
+        foreach($postTags as $tag)
+        {
+            $tagNames[] = $tag->name;
+        }
       }
   ?>
   <meta name="keywords" content="<?php echo implode($tagNames,", "); ?>" />


### PR DESCRIPTION
Haciendo uso de la plantilla de Wordpress para la creación del sitio para nuestro círculo (Podem Patraix) hemos detectado un error que se da en la carga de páginas sin etiquetas. He añadido un `if` para prevenir este error en caso de que el método `get_the_tags()` devuelva un valor nulo.
